### PR TITLE
Fix compiler warnings, analyzer warnings and a bug

### DIFF
--- a/identifier/language_database.cpp
+++ b/identifier/language_database.cpp
@@ -34,7 +34,7 @@ LanguageDatabase::~LanguageDatabase(void)
 	for (i = 0; i < LANGUAGE_DATABASE_HASH_TABLE_SIZE; i++)	{
 		if (HashTable[i]) {
 			TriGram *current = HashTable[i];
-			TriGram *next = current->next;
+			TriGram *next;
 			while (current) {
 				next = current->next;
 				delete current;
@@ -61,10 +61,14 @@ bool LanguageDatabase::LoadFile(const char *pathName, const char *fileName, cons
 {
 	if (!pathName || !fileName)
 		return false;
-	
-	char *fullPath = new char[strlen(pathName) + strlen(fileName) + 1];
-	strcpy (fullPath, pathName);
-	strcat (fullPath, fileName);
+
+	size_t path_len = strlen(pathName);
+	size_t file_len = strlen(fileName);
+	char *fullPath = new char[path_len + file_len + 1];
+	fullPath[path_len+file_len] = 0;
+
+	strncpy (fullPath, pathName, path_len+1);
+	strncat (fullPath, fileName, file_len);
 
 	std::ifstream::pos_type fileSize;
 	std::ifstream file (fullPath, std::ios::in|std::ios::binary|std::ios::ate);

--- a/identifier/language_sample.cpp
+++ b/identifier/language_sample.cpp
@@ -24,15 +24,14 @@ LanguageSample::LanguageSample(LanguageDatabase *languageDatabase, const char *s
 		return;
 	
 	// Convert sample to UCS-4 (UTF-32)
-	int length = strlen(sampleText);
+	int length = (int)strlen(sampleText);
 	if (length <= 3)
 		return;
 	if (length > MaxInputLength)
 		length = MaxInputLength;
 	wchar_t *widesample = new wchar_t[length];
 	memset(widesample, 0, sizeof(wchar_t)*length);
-	size_t wide_string_size; 
-	wide_string_size = utf8_to_wchar(sampleText, length, widesample, sizeof(wchar_t) * length, 0);
+	utf8_to_wchar(sampleText, length, widesample, sizeof(wchar_t) * length, 0);
 	widesample[length - 1] = 0;
 
 	// Split sample into trigrams
@@ -128,7 +127,7 @@ LanguageSample::~LanguageSample()
 		return;
 	
 	TriGram *current = Trigrams;
-	TriGram *next = current->next;
+	TriGram *next;
 	while (current) {
 		next = current->next;
 		delete current;

--- a/identifier/unicode/utf8.c
+++ b/identifier/unicode/utf8.c
@@ -133,7 +133,7 @@ utf8_to_wchar(const char *in, size_t insize, wchar_t *out, size_t outsize,
 		}
 
 		/* does the sequence header tell us truth about length? */
-		if (lim - p <= n - 1) {
+		if ((size_t)(lim - p) <= (n - 1)) {
 			if ((flags & UTF8_IGNORE_ERROR) == 0)
 				return (0);
 			n = 1;
@@ -260,7 +260,7 @@ wchar_to_utf8(const wchar_t *in, size_t insize, char *out, size_t outsize,
 		if (out == NULL)
 			continue;
 
-		if (lim - p <= n - 1)
+		if ((size_t)(lim - p) <= n - 1)
 			return (0);		/* no space left */
 
 		/* make it work under different endians */
@@ -272,39 +272,39 @@ wchar_to_utf8(const wchar_t *in, size_t insize, char *out, size_t outsize,
 			break;
 
 		case 2:
-			p[1] = _NXT | oc[3] & 0x3f;
-			p[0] = _SEQ2 | (oc[3] >> 6) | ((oc[2] & 0x07) << 2);
+			p[1] = _NXT | (oc[3] & 0x3f);
+			p[0] = (u_char)(_SEQ2 | (oc[3] >> 6) | ((oc[2] & 0x07) << 2));
 			break;
 
 		case 3:
-			p[2] = _NXT | oc[3] & 0x3f;
-			p[1] = _NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2);
+			p[2] = _NXT | (oc[3] & 0x3f);
+			p[1] = (u_char)(_NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2));
 			p[0] = _SEQ3 | ((oc[2] & 0xf0) >> 4);
 			break;
 
 		case 4:
-			p[3] = _NXT | oc[3] & 0x3f;
-			p[2] = _NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2);
-			p[1] = _NXT | ((oc[2] & 0xf0) >> 4) |
-			    ((oc[1] & 0x03) << 4);
+			p[3] = _NXT | (oc[3] & 0x3f);
+			p[2] = (u_char)(_NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2));
+			p[1] = (u_char)(_NXT | ((oc[2] & 0xf0) >> 4) |
+			    ((oc[1] & 0x03) << 4));
 			p[0] = _SEQ4 | ((oc[1] & 0x1f) >> 2);
 			break;
 
 		case 5:
-			p[4] = _NXT | oc[3] & 0x3f;
-			p[3] = _NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2);
-			p[2] = _NXT | ((oc[2] & 0xf0) >> 4) |
-			    ((oc[1] & 0x03) << 4);
+			p[4] = _NXT | (oc[3] & 0x3f);
+			p[3] = (u_char)(_NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2));
+			p[2] = (u_char)(_NXT | ((oc[2] & 0xf0) >> 4) |
+			    ((oc[1] & 0x03) << 4));
 			p[1] = _NXT | (oc[1] >> 2);
-			p[0] = _SEQ5 | oc[0] & 0x03;
+			p[0] = _SEQ5 | (oc[0] & 0x03);
 			break;
 
 		case 6:
-			p[5] = _NXT | oc[3] & 0x3f;
-			p[4] = _NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2);
-			p[3] = _NXT | (oc[2] >> 4) | ((oc[1] & 0x03) << 4);
+			p[5] = _NXT | (oc[3] & 0x3f);
+			p[4] = (u_char)(_NXT | (oc[3] >> 6) | ((oc[2] & 0x0f) << 2));
+			p[3] = (u_char)(_NXT | (oc[2] >> 4) | ((oc[1] & 0x03) << 4));
 			p[2] = _NXT | (oc[1] >> 2);
-			p[1] = _NXT | oc[0] & 0x3f;
+			p[1] = _NXT | (oc[0] & 0x3f);
 			p[0] = _SEQ6 | ((oc[0] & 0x40) >> 6);
 			break;
 		}

--- a/identifier/unicode_tester.cpp
+++ b/identifier/unicode_tester.cpp
@@ -102,7 +102,7 @@ const char *UnicodeTester::GetLanguage()
 
 const char *UnicodeTester::GetLanguageByCode(unsigned int languageCode) const
 {
-	if (languageCode < 0 || languageCode >= UT_TOTAL_LANGUAGES)
+	if (languageCode >= UT_TOTAL_LANGUAGES)
 		return 0;
 	
 	if (languageCode == UT_JAPANESE) {

--- a/identifier/unicode_tester.h
+++ b/identifier/unicode_tester.h
@@ -12,7 +12,7 @@
 #include "options.h"
 
 
-#define UT_TOTAL_LANGUAGES 9
+#define UT_TOTAL_LANGUAGES 10
 #define UT_JAPANESE 0
 #define UT_CHINESE 1
 #define UT_KOREAN 2


### PR DESCRIPTION
This fixes all warnings generated by modern versions of clang (3.4) and GCC (4.8.1), as well as clang's static analyzer (reporting unused stores). Also fixes a bug in the UT_TOTAL_LANGUAGES value which did not include cyrillic.
